### PR TITLE
fix: shell-quote vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2549,7 +2549,7 @@
         "resolve": "1.8.1",
         "shallow-copy": "0.0.1",
         "shasum": "1.0.2",
-        "shell-quote": "0.0.1",
+        "shell-quote": "1.6.1",
         "stream-browserify": "1.0.0",
         "string_decoder": "0.10.31",
         "subarg": "1.0.0",


### PR DESCRIPTION
Update package.json to fix shell-quote vulnerability.
See github alert: https://github.com/blestab/mws-restaurant-reviews-app/network/alerts